### PR TITLE
COMP: Update cppzmq to fix macOS default initialization of an object of const type

### DIFF
--- a/SuperBuild/External_cppzmq.cmake
+++ b/SuperBuild/External_cppzmq.cmake
@@ -20,13 +20,13 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/zeromq/cppzmq.git"
+    "${EP_GIT_PROTOCOL}://github.com/slicer/cppzmq.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "master"
+    "64c20498728f7fff12ebd2d1a4623844830748ef" # slicer-v4.7.0-2020-04-25-3746e5c
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

$ git shortlog master..64c204987 --no-merges
Jean-Christophe Fillion-Robin (1):
      Fix error: default initialization of an object of const type