### PR TITLE
ENH: Update nlohmann/json

### DIFF
--- a/SuperBuild/External_nlohmann_json.cmake
+++ b/SuperBuild/External_nlohmann_json.cmake
@@ -26,7 +26,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "v3.1.1"
+    "v3.7.3"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog v3.1.1..v3.7.3 --no-merges
0xflotus (1):
      did you mean 'serialization'?

Andreas Schwab (1):
      Do proper endian conversions

Anthony VH (1):
      Moved test for #1647 regression to regressions file.

Anthony Van Herrewege (3):
      Fix #1647: non-member operator== breaks enum (de)serialization.
      Add test for #1647.
      Don't capture json input by value (fixed #1822).

Antonio Borondo (6):
      Fix warning
      Generate header
      Change implementation to use templates
      Fix error: explicit specialization in non-namespace scope
      Fix error: 'wide_string_input_helper' was not declared in this scope
      Remove anonymous namespace

Axel Huebl (7):
      CMake: 3.8+ is Sufficient
      Package Manager: Spack
      Fix EOL Whitespaces & CMake Spelling
      CMake: Optional Install if Embedded
      Remove EOL whitespaces in natvis
      merge_patch: rename parameter
      Amalgamate Headers

Ben Berman (3):
      Improve error messages for error 305
      Fix tests for improved error 305(hopefully)
      Replace "key-style argument" with "string argument"

Bruno Oliveira (1):
      Add instructions about using nlohmann/json with the conda package manager

Camille Bégué (2):
      Fix issue #1805
      Add restriction for tuple specialization of to_json

Carlos O'Ryan (1):
      Fix trivial typo in comment.

Chris Harris (1):
      Patch nlohmann/json for GCC 4.8

Chuck Atkins (8):
      Make the CMake install dir user-configurable
      Enable target namespaces and build dir project config
      Use a version check to provide backwards comatible imported target names.
      cmake: fix package config to deal with versioning and namespaces
      cmake: add import config tests
      docs: add a note in the readme about using the CMake imported target
      Turn off additional deprecation warnings for GCC.
      docs: Add additional CMake documentation

Danielc (1):
      fixed compile error for #1045; to_json for iternation_proxy_internal was needed

David Avedissian (3):
      Implement SFINAE friendly iterator_traits and use that instead.
      Changes requested from code review.
      Code review.

David Guthrie (1):
      Reordered the code. It seems to stop clang 3.4.2 in RHEL 7 from crashing intermittently.

Dennis Fischer (1):
      Export package to allow builds without installing

Eli Schwartz (2):
      release: add singleinclude and meson.build to include.zip
      README: describe how to use json as a meson subproject

Elvis Oric (1):
      Disable installation when used as meson subproject. #1463

Evan Nemerson (1):
      Update Hedley to v11.

Ferenc Nasztanovics (1):
      Change macros to numeric_limits #1483

Florian Pigorsch (1):
      Fix some spelling errors - mostly in comments & documentation.

Gregorio Litenstein (1):
      Thirdparty benchmark: Fix Clang detection.

Guillaume Racicot (10):
      basic_json now supports getting many type of strings
      Amalgamated headers
      Amalgamate single include
      Added test for conversion to string_view
      Added test for string conversion with string_view
      Disabled implicit conversion to string_view on MSVC 15.13 and older
      Set MSVC version from 1514 and older
      Re-added external_constructor with string compatible types
      Aligned template declaration
      Fixed check for compatible string type

Henry Fredrick Schreiner (1):
      Adding 4.8 test to travis

Hyeon Kim (2):
      Add new JSON_INTERNAL_CATCH macro function
      Fix #1213

Isaac Nickaein (29):
      Specify target platform in generator name
      Increase stack size for VS2017 Win x64 on Appveyor
      Improve dump_integer performance by implementing a more efficient int2ascii
      Add benchmark for small integers
      Add unit tests for dump_integer
      Add unit test for parsing deeply-nested array
      During destruction, flatten children of objects to avoid recursion
      Fix documentation
      Implement contains() to check existence of a key
      Add unit-test for contains() member function
      Fix typo in README.ME
      Fix broken links to documentation
      :pencil2: Fix a typo in README
      :pencil2: Fix brew instructions in README
      :pencil2: Fix links to create an issue page
      Add Debug builds for AppVeyor
      Increase timeout of test-unicode_all in Debug build
      Add a separate build with Windows.h included
      Workaround msvc2015 bug with explicit copy-constructor for const_iterator
      Avoid collision of ::max with windows.h macro
      Appveyor: Set build mode explicitly
      Appveyor: Set timeout of unit-tests in appveyor.yml instead of CMake
      :memo: Improve doc on const_inter constructor
      CI: Skip test-unit_all on MSVC Debug builds
      Reduce depth in unit-test to avoid choking valgrind
      Move deep JSON test to a separate unit-test
      Remove harmful vector::reserve during destruction (#1837)
      Cleanups
      Reserve stack only for top-level items

Ivor Wanders (1):
      Use C++11 features supported by CMake 3.1.

James Upjohn (1):
      Fixed incorrect version number in README

Jan Schöppach (2):
      Fix typo
      Fix typo in single_include, too

Jef LeCompte (1):
      Updated year in README.md

Jonathan Dumaresq (12):
      Add the possibility of using FILE * from cstdio library to read a file. This enable the possibility of using low eand device with this library.
      Add the possibility of using FILE * from cstdio library to read a file. This enable the possibility of using low eand device with this library.
      remove non usefull code. Add small description
      remove non usefull code.
      add tests to cover the new input adapter
      new unified json.hpp generated with make amalgamate
      remove comment
      remove the const attribute
      refactor unit test in case of throw, the fclose will not be called. using unique_ptr with custom destructor will ensure that
      create single json.hpp file
      use namespace std when possible. Change the name of private variable.
      Forget one std::FILE

Julian Becker (27):
      BSON: serialization of non-objects is not supported
      BSON: Support empty objects
      BSON: Object with single boolean
      BSON: support doubles
      BSON: Support objects with string members
      BSON: support objects with null members
      BSON: support objects with int32 members
      BSON: support objects with int64 members
      BSON: unsigned integers
      BSON: support objects with objects as members
      BSON: test case for a more complex document
      BSON: Support for arrays
      BSON: Bugfix for non-empty arrays
      Fix: Add missing `begin()` and `end()` member functions to `alt_string`
      BSON: Added test case for the different input/output_adapters
      BSON: Fixed hangup in case of incomplete bson input and improved test coverage
      BSON: Extend `binary_reader::get_number` to be able to hanlde little endian input to get rid of `binary_reader::get_number_little_endian`
      BSON: Reworked `binary_reader::get_bson_cstr()`
      BSON: Improved documentation and error handling/reporting
      BSON: Reworked the `binary_writer` such that it precomputes the size of the BSON-output. This way, the output_adapter can work on simple output iterators and no longer requires random access iterators.
      BSON: allow and discard values and object entries of type `value_t::discarded`
      BSON: throw json.exception.out_of_range.407 in case a value of type `std::uint64_t` is serialized to BSON. Also, added a missing EOF-check to binary_reader.
      BSON: Adjusted documentation of `binary_writer::to_bson()`
      BSON: throw `json.exception.out_of_range.409` in case a key to be serialized to BSON contains a U+0000
      BSON: Hopefully fixing ambiguity (on some compilers) to call to string::find()
      BSON: fixed incorrect casting in unit-bson.cpp
      BSON: Improved exception-related tests and report location of U+0000 in the key-string as part of `out_of_range.409`-message

Julien Hamaide (2):
      Allow items() to be used with custom string
      Provide default implementation for int_to_string, but allow for overloaded function

Julius Rakow (4):
      meson: fix include directory
      meson: add multiple headers target
      :memo: link to cppreference via HTTPS
      :memo: fix links to cppreference named requirements

Kevin Tonon (2):
      Using target_compile_features to specify C++ 11 standard
      Update CMake to latest on Travis

Konstantin Podsvirov (1):
      Package Manager: MSYS2 (pacman)

Kostiantyn Ponomarenko (2):
      Add version and license to meson.build
      Add Meson related info to README

Laurent Stacul (1):
      Fix gcc9 build error test/src/unit-allocator.cpp (Issue #1472)

Macr0Nerd (2):
      Added to_string and added basic tests
      Added to_string (with ugly macro) and tests

Manvendra Singh (1):
      readme: fix typo

Mark Beckwith (2):
      typo in README
      docs: README type

Matthias Möller (3):
      remove stringstream dependency
      typo
      added char cast

Matěj Plch (1):
      remove extra semicolon

Michael Gmelin (2):
      Make section names unique in loops, as catch doesn't support duplicate sections, see also https://github.com/catchorg/Catch2/issues/816#issuecomment-278268122
      Exclude bytewise comparison in certain tests. These tests never worked - they weren't run before d5aaeb4.

Michele Caini (3):
      Fixed broke links to RFC7159
      Fixed broken links to operator[]() and at()
      Fixed broken links in the README file

Miguel Sacristan (1):
      Fix and add test's for SFINAE problem

Mike Bogdanov (2):
      pvs_studio fix. misprinted condition
      did make amalgamate

Millian Poquet (1):
      :meson: install headers + pkg-config

Niels Lohmann (343):
      :sparkles: added a SAX parser #971
      :hammer: fixed test cases to be more robust
      :white_check_mark: added more tests for SAX parsing
      :hammer: removed a logic error and improved coverage
      :ok_hand: fixed some compiler warnings
      :memo: overworked README
      :recycle: refactored SAX parser
      :hammer: added a SAX-DOM-Parser
      :rotating_light: fixed a linter warning
      :green_heart: fixed test case
      :hammer: added error messages to SAX interface
      :hammer: added SAX-DOM-Parser
      :hammer: simplified SAX-DOM parser
      :hammer: using the SAX-DOM parser
      :green_heart: added regression tests for #972 and #977
      :recycle: refined SFINAE to fix some warnings
      :green_heart: added another test case
      :fire: replaced acceptor with SAX parser
      :ok_hand: fixed some more warnings
      :hammer: trying to fix the leak
      :fire: removing failing test (work on this in branch "leak")
      :ambulance: hopefully fixed the memory leak
      :memo: cleanup after #1001
      :ok_hand: made changes proposed in #1001
      :green_heart: improved test coverage
      :recycle: refactored binary readers to use a SAX parser
      :hammer: cleaner exception interface
      :memo: thanks for #1006
      :recycle: adjusting lexer/parser in symmetry to #1006
      :hammer: fixed compilation error
      :checkered_flag: fixed an MSVC warning
      :checkered_flag: experimenting with /Wall
      :checkered_flag: moved /Wall to CMake
      :rewind: oops
      :bookmark: set version to 3.1.2
      :bookmark: set version to 3.1.2
      :recycle: implemented a non-recursive parser
      :white_check_mark: improved test coverage
      :hammer: cleanup
      :construction: started a SAX/DOM/callback parser
      :hammer: some refactoring
      :recycle: proper use of SAX parser for binary formats
      :sparkles: implemented non-throwing binary reader
      :white_check_mark: improved test coverage
      :memo: updated documentation
      :white_check_mark: more tests
      :white_check_mark: improved coverage
      :white_check_mark: improved test coverage
      :hammer: changed SAX interface
      :ambulance: fix for #1021
      :hammer: improved code #1021
      :hammer: realized callback parser wirh SAX interface #971
      :memo: fixed example for operator> #1029
      :green_heart: fixed Valgrind options #1030
      :hammer: using a vector<bool> for the parser hierarchy
      :hammer: cleanup
      :construction: added input adapter for wide strings #1031
      :hammer: trying to make tests run with MSVC #1031
      :hammer: trying to make tests run with MSVC #1031
      :ok_hand: fixed compiler warnings #1031
      :white_check_mark: improved test coverage #1031
      :hammer: removing unget_character() function from input adapters #834
      :hammer: cleanup
      :ambulance: fixed commit 1e08654
      :hankey: first try on #1045
      :construction_worker: added Xcode 9.3 builder
      :memo: updated THANKS list
      :fire: removed commented-out test cases #1060
      :page_facing_up: added SPDX-License-Identifier
      :memo: added public key used for commits and releases
      :wrench: update issue templates
      :fire: removed old issue template
      Update issue templates
      :hammer: removed unget function for wstring parsers
      :ambulance: fixed error in callback logic
      :white_check_mark: added more tests from recent nst's JSONTestSuite
      :white_check_mark: adjusted test cases
      :zap: keys are now returned as const reference #1098
      :ok_hand: mitigating cppcheck bug #1101
      :hammer: only calculate array index string when needed #1098
      :memo: added documentation
      :ambulance: adjusted Fuzzer to new parser
      :memo: documentation to avoid future issues like #1108
      :lipstick: cleanup
      :memo: documentation fix
      :memo: fix for #1052 #1139
      :rotating_light: removed compiler warnings
      :rotating_light: fixed more compiler warnings
      :rotating_light: fixed more compiler warnings
      :construction_worker: tryping different platforms for AppVeyor
      :hammer: small refactoring to improve branch coverage
      :lipstick: fixed indentation
      :construction_worker: experimenting with AppVeyor and MinGW
      :construction_worker: forgot quotes
      :construction_worker: set build type
      :construction_worker: using help from https://stackoverflow.com/a/48509334/266378
      :construction_worker: forgot old PATH
      :construction_worker: trying a more recent compiler
      :hammer: fixed escaping for MinGW
      :construction_worker: using Ninja to speed up build
      :construction_worker: choosing correct image
      :memo: mentioned MinGW in README
      :hammer: added macro to disable compiler check #1128
      :hammer: cleanup after #1134
      :memo: added note about CocoaPods #1148
      :checkered_flag: fix for #1168
      :ambulance: fix for #1169
      :checkered_flag: trying to fix C2440 error
      :checkered_flag: implicit conversion is not allowed with MSVC
      :construction_worker: added more CI workers
      :construction_worker: added more CI workers
      :memo: updated documentation of used compilers
      :art: reindented code
      :rotating_light: fixing a MinGW warning #1192
      :hammer: fixed a MinGW error #1193
      :rotating_light: fixed some compiler warnings
      :memo: overworked documentation
      :bug: fixed callback-related issue (https://github.com/nlohmann/json/issues/971#issuecomment-413678360)
      :rotating_light: fixed a compiler warning
      :memo: release preparation
      :arrow_up: Catch 1.12.0
      :memo: added example for sax_parse
      :bookmark: preparing 3.2.0 release
      :hammer: fixed amalgamation
      :bookmark: set version to 3.2.0
      :rotating_light: fixed a compiler warning #1224
      :art: cleanup after #1228
      :construction_worker: adding Xcode 10 worker
      :memo: added lgtm.com badge
      :rotating_light: fixed a compilation issue with ICPC #755
      :rotating_light: fixed a compilation issue with ICPC #755
      :memo: added Wandbox link #1227
      :memo: added Wandbox link #1227
      :lipstick: cleaned code
      :memo: updated contributor list
      :memo: small update to pass test suite
      :bookmark: set version to 3.3.0
      :bookmark: set version to 3.3.0
      :rotating_light: fixed some linter warnings
      :rotating_light: fixed another linter warning
      :wheelchair: added line positions to error messages
      :bug: fixed a bug in the unget function
      :rotating_light: fixed some clang-tidy warnings
      :rotating_light: fixed some more clang-tidy warnings
      :memo: fixed documentation
      :ambulance: fixed compilation error
      :wheelchair: improved parse error messages
      :ambulance: fixed compilation error
      :construction: proposal for different error handlers #1198
      :wheelchair: improved error messages for binary formats #1288
      :construction: overworked error handlers #1198
      :green_heart: added tests #1198
      :construction: respect ensure_ascii parameter #1198
      :construction: fixed an issue with ensure_ascii #1198
      :construction: fixed test cases #1198
      :green_heart: additional tests from the Unicode spec #1198
      :ok_hand: replaced static_cast to CharType by conversion function #1286
      :pencil2: fixed a typo #1314
      :memo: added a note to the discussion #1286
      :memo: updated documentation #1314
      :construction: some changes to the BSON code
      :hammer: fixed fuzz code to avoid false positives in case of discarded values
      :art: clean up binary formats
      :hammer: added fix for arrays
      :rotating_light: fixed compiler warnings
      :rotating_light: fixed coverage
      :ok_hand: fixed comment #1320
      :ok_hand: added another conversion function #1315
      :rotating_light: fixed another linter warning
      :sparkles: added NLOHMANN_JSON_SERIALIZE_ENUM marco #1208
      :rotating_light: fixed another linter warning
      :zap: replaced vector by array #1323
      :hammer: small improvements
      :rotating_light: fixed a linter warning
      :rotating_light: fixed some more linter warnings
      :bug: fixed a bug parsing BSON strings #1320
      :pencil2: fixed some typos
      :memo: added examples for BSON functions
      :rotating_light: fixed another linter warning
      :lipstick: fixed indentation
      :ambulance: fixed #1319
      :bookmark: set version to 3.4.0
      :bookmark: set version to 3.4.0
      :rotating_light: fixed a linter warning
      :lipstick: cleanup
      :checkered_flag: adding parentheses around std::snprintf calls #1337
      :rotating_light: fixed warning #1364
      :rotating_light: fixed a warning
      :art: fixed header
      :memo: added contributors to 3.5.0
      :rotating_light: fixed two warnings
      :memo: update documentation
      :memo: updated documentation
      :memo: formatted picture
      :memo: updated documentation for items() function
      :bookmark: set version to 3.5.0
      :rotating_light: fixed some warnings
      :rotating_light: fixed PVS V567 warning
      :memo: added description on how to use NuGet package #1132
      :arrow_up: upgraded Catch and Google Benchmark
      :bulb: improved documentation for parsing without exceptions #1405
      :rotating_light: fixed another linter warning
      :hammer: fixed includes
      :rotating_light: fixed another linter warning #1400
      :construction: trying nodiscard attribute #1433
      :hammer: trying code from https://godbolt.org/z/-tLO1K
      :bug: fixed integer overflow in dump function #1447
      :bug: added missing include #1500
      :construction_worker: trying new Travis workers
      :green_heart: fix compiler selection
      :memo: updated documentation of CI
      :rotating_light: fix MSVC warning #1502
      :construction_worker: removing more retired Travis images
      :fire: removing Xcode 6.4 builder
      :rotating_light: fixed some warnings
      :rotating_light: fixed warnings
      :rotating_light: fixed warnings
      :fire: removing unstable macOS builds on Traivs
      :rotating_light: fixed more warnings
      :heavy_plus_sign: adding cpplint
      :rotating_light: adding targets for static analyzers
      :rotating_light: fixed warnings
      :arrow_up: updated Doxyfile
      :construction_worker: overworked clang-tidy target
      :green_heart: fix CI and #1521
      :memo: added documentation
      :construction_worker: added targets for infer and oclint
      :hammer: clean up
      :green_heart: forgot two semicolons
      :art: cleanup
      :memo: added documentation
      :memo: updated documentation
      :memo: completed documentation index page
      :busts_in_silhouette: added contributors
      :rotating_light: fixed a warning
      :bookmark: set version to 3.6.0
      :bookmark: set version to 3.6.0
      :speech_balloon: update issue templates
      :rotating_light: fixed some warnings #1527
      :alembic: added funding link
      :bug: fixed regression #1530
      :checkered_flag: fixed a compilation error in MSVC #1531
      :bug: fixed regression #1530
      :bookmark: set version to 3.6.1
      :checkered_flag: trying to use constructors from std::allocator #1536
      :construction_worker: trying doozer
      :construction_worker: added cmake
      :construction_worker: using raspbian
      :construction_worker: added Fedora and CentOS
      :construction_worker: add test output to avoid timeout
      :construction_worker: fixed buildenv values
      :construction_worker: fixed a typo
      :construction_worker: need more recent cmake for CentOS
      :construction_worker: use recent cmake
      :construction_worker: fixed syntax error
      :construction_worker: fixed installation
      :construction_worker: need to install g++
      :construction_worker: install correct g++
      :construction_worker: install g++
      :construction_worker: fixed package name
      :construction_worker: fixed paths
      :construction_worker: unified paths
      :construction_worker: fixed syntax
      :construction_worker: fixed timeout
      :construction_worker: increased timeout
      :construction_worker: fixed required packages
      :construction_worker: skip certificate check
      :construction_worker: forgot path to ctest
      :construction_worker: adding xenial-armhf
      :construction_worker: fixed timeout
      :construction_worker: version output
      :memo: added Doozer to README
      :wrench: overworked maintaner targets
      :arrow_up: added script to update cpplint
      :art: fixed indentation
      :hammer: minor changes to maintainer targets
      :fire: removed unsupported flag
      :alembic: trying fastcov
      :hammer: using --exclude-gcov to exclude files
      :construction_worker: trying CircleCI
      :construction_worker: full workflow
      :construction_worker: fixed path
      :construction_worker: adding concurrency
      :construction_worker: Ninja seems not to work
      :hammer: relaxed requirements to coverage
      :rotating_light: silenced a warning
      :building_construction: adding anonymous namespace
      :arrow_up: updated fastcov
      :arrow_up: updated fastcov
      :memo: updated README
      :hammer: small cleanup
      :arrow_up: updated fastcov
      :hammer: overworked coverage targets
      :memo: mention 302 exception in value() documentation #1601
      :memo: mention json type in documentation start page #1616
      :sparkles: add contains function for JSON pointers
      :sparkles: make emplace_back return a reference #1609
      :alembic: add Hedley annotations
      :hammer: add NLOHMANN_JSON prefix and undef macros
      :rotating_light: fix warning
      :truck: rename Hedley macros
      :construction: add more annotations
      :rotating_light: fix warnings
      :memo: remove HEDLEY annotation from documentation
      :rotating_light: fix compiler warnings
      :ambulance: fix compiler errors
      :rotating_light: fix linter warning
      :fire: remove leftover file
      :hammer: adjust paths
      :hammer: adjust version
      :hammer: fix release target
      Update Makefile
      :bookmark: set version to 3.7.0
      :pencil: update documentation
      :pencil: update documentation
      :busts_in_silhouette: update contributors
      :lock: add security policy
      :construction_worker: adjust maintainer scripts
      :pencil2: fix a typo
      :construction_worker: try GitHub Actions
      :construction_worker: add test step
      :memo: add OSS Fuzz status badge
      :rotating_light: fix warning
      :pencil: add comment on JSON_THROW_USER, JSON_TRY_USER, and JSON_CATCH_USER
      :busts_in_silhouette: add CODEOWNERS file
      :busts_in_silhouette: update contributors
      :rotating_light: fix UBSAN warnings
      :memo: update examples
      :loud_sound: add version output
      :construction_worker: add Xcode 10.2
      :hammer: remove full path
      :construction_worker: add Xcode 10.2
      :arrow_up: upgrade Doctest to 2.3.5
      :bug: fix conversion to std::valarray
      :rotating_light: fix linter errors
      :rotating_light: fix linter errors
      :busts_in_silhouette: update contributors
      :bookmark: set version to 3.7.1
      :rotating_light: fix a linter warning
      :hammer: add path
      :bookmark: set version to 3.7.2
      :art: fix inconsistent operator style
      :bookmark: set version to 3.7.3

Patrick Boettcher (3):
      allow push_back() and pop_back() calls on json_pointer
      :rotating_light: fixed unused variable warning
      JSON-pointer: add operator+() returning a new json_pointer

Pratik Chowdhury (1):
      Added Support for Structured Bindings

Sonu Lohani (1):
      Fixed compiler error in VS 2015 for debug mode https://github.com/nlohmann/json/issues/1114

Taylor Howard (1):
      Added explicit converstion to std::string_view. Fixes failing test with GCC 8.3

Thomas Braun (15):
      .travis.yml: Add gcc 9 and compile with experimental C++20 support
      test/CMakeLists.txt: Remove trailing whitespace
      .travis/cmake: Rework clang sanitizer invocation
      input_buffer_adapter: Fix handling of nullptr input
      external_constructor<std::valarray>: Handle empty array properly
      .travis.yml: Increase the timeout to 45 minutes
      Fix outputting extreme integer values in edge cases
      Add regression test for dumping the minimum value of int64_t
      Add serialization unit tests for extreme integer values
      test/CMakeLists.txt: Use an explicit list instead of GLOB
      appveyor: Pass the generator platform explicitly
      test/cmake_import: Pass the generator platform required by MSVC 2019
      iteration_proxy: Fix integer truncation from std::size_t to int
      appveyor.yml: Add MSVC 16 2019 support
      appveyor.yml: Add debug build on x64 and VS 2019

Théo DELRIEU (32):
      missing CHECK_NOTHROW in unit-udt
      support construction from other basic_json types
      Provide a from_json overload for std::map
      from_json: add missing template arguments for std::map
      from_json: add overload for std::unordered_map
      run make amalgamate
      split meta.hpp, add detected_t (used to define concepts)
      use templates in the sax interface instead of virtuals
      remove no_limit constant and default values
      use abstract sax class in parser tests
      add static_asserts on SAX interface
      fix void_t for older compilers
      use detected instead of has_* traits
      refactor is_compatible_object_type
      refactor is_compatible_string_type
      refactor is_compatible_array_type
      refactor is_compatible_integer_type
      refactor is_compatible_type, remove conjunction & co
      do not check for compatible_object_type in compatible_array_type
      refactor from/to_json(CompatibleArrayType)
      make to_json SFINAE-correct
      make from_json SFINAE-correct
      remove now-useless traits. check for is_basic_json where needed
      Fix issue #1237
      Add basic_json::get_to function.
      add constraints for variadic json_ref constructors
      add new is_constructible_* traits used in from_json
      add a note to maintainers in type_traits.hpp
      recommend using explicit from JSON conversions
      make sure values are overwritten in from_json overloads
      add built-in array support in get_to
      tests: fix coverage

Tommy Nguyen (1):
      Use GNUInstallDirs instead of hard-coded path.

Tsz-Ho Yu (1):
      Fix -Wno-sometimes-uninitialized by initializing "result" in parse_sax

Viktor Kirilov (1):
      Update CMakeLists.txt

Vitaliy (4):
      test (non)equality for alt_string implementation
      define global operator< for const char* and alt_string
      forward declarations to make new compilers happy
      simplify templates for operators, add more checks

Vitaliy Manushkin (5):
      dump to alternate implementation of string, as defined in basic_json template
      dump to alternate implementation of string, as defined in basic_json template (changes to amalgamated code)
      forward alternative string class from output_adapter to output_string_adapter
      add unit test: checking dump to alternative string type
      test refactoring

Watal M. Iwasaki (1):
      Remove C++17 extension warning from clang; #1535

Wilson (1):
      Make integration section concise

Xav83 (3):
      Correct a warning from cppcheck:
      Correct a warning from cppcheck:
      Runs make amalgamate on the project.

Yann E. MORIN (1):
      buildsystem: relax requirement on cmake version

christian (1):
      Make json_pointer::back const (resolves #1764)

garethsb-sony (5):
      Add operator/= and operator/ to construct a JSON pointer by appending two JSON pointers, as well as convenience op/= and op= to append a single unescaped token or array index; inspired by std::filesystem::path
      Attempt to satisfy Coveralls by adding a test for (unchanged) operator std::string
      Rename private json_pointer::is_root as public json_pointer::empty for consistency with std::filesystem::path
      Add json_pointer::parent_pointer (cf. std::filesystem::path::parent_path)
      Tests for json_pointer::empty and json_pointer::parent_pointer

kevinlul (3):
      Fix #1642
      Add regression tests for #1642
      Remove boolean regression test for #1642

kjpus (1):
      Link to issue #958 broken

knilch (1):
      unit-testsuites.cpp: fix hangup if file not found

lieff (1):
      fix GCC 7.1.1 - 7.2.1 on CentOS closes https://github.com/nlohmann/json/issues/670

mandreyel (1):
      Move lambda out of unevaluated context

martin-mfg (1):
      fix typo in readme

mefyl (1):
      Set eofbit on exhausted input stream.

njlr (1):
      Update README.md

onqtam (9):
      moved from Catch to doctest for unit tests
      fixing osx builds - had forgotten to define this for the object file where the test runner is compiled
      this should really fix the XCode 6/7 builds
      updated doctest to version 2.3.1 released today
      reverted the removal of this if/else branching - this is the easiest way to get -std=c++0x support
      fixed a bunch of warnings from the Makefile from the root of the repo
      finished the last of the warnings
      tabs instead of spaces...
      fixing the remaining of the pedantic gcc/clang target warnings

past-due (1):
      Disable -Wmismatched-tags warning on tuple_size / tuple_element

scinart (3):
      flush buffer in serializer::dump_escaped case UTF8_REJECT
      fix typo
      move newly-added tests in unit-regression.cpp

whitesource-bolt-for-github[bot] (1):
      Add .whitesource configuration file
```