### PR TITLE
ENH: Update nlohmann/json from v3.1.1 to v3.2.0

### DIFF
--- a/SuperBuild/External_nlohmann_json.cmake
+++ b/SuperBuild/External_nlohmann_json.cmake
@@ -26,7 +26,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "v3.1.1"
+    "v3.2.0"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ Axel Huebl (2):
      CMake: 3.8+ is Sufficient
      Package Manager: Spack

Carlos O'Ryan (1):
      Fix trivial typo in comment.

Chuck Atkins (2):
      Make the CMake install dir user-configurable
      Enable target namespaces and build dir project config

Danielc (1):
      fixed compile error for #1045; to_json for iternation_proxy_internal was needed

Guillaume Racicot (10):
      basic_json now supports getting many type of strings
      Amalgamated headers
      Amalgamate single include
      Added test for conversion to string_view
      Added test for string conversion with string_view
      Disabled implicit conversion to string_view on MSVC 15.13 and older
      Set MSVC version from 1514 and older
      Re-added external_constructor with string compatible types
      Aligned template declaration
      Fixed check for compatible string type

Hyeon Kim (1):
      Add new JSON_INTERNAL_CATCH macro function

James Upjohn (1):
      Fixed incorrect version number in README

Jan Schöppach (2):
      Fix typo
      Fix typo in single_include, too

Julius Rakow (4):
      meson: fix include directory
      meson: add multiple headers target
      :memo: link to cppreference via HTTPS
      :memo: fix links to cppreference named requirements

Kevin Tonon (2):
      Using target_compile_features to specify C++ 11 standard
      Update CMake to latest on Travis

Matthias Möller (3):
      remove stringstream dependency
      typo
      added char cast

Michael Gmelin (2):
      Make section names unique in loops, as catch doesn't support duplicate sections, see also https://github.com/catchorg/Catch2/issues/816#issuecomment-278268122
      Exclude bytewise comparison in certain tests. These tests never worked - they weren't run before d5aaeb4.

Mike Bogdanov (2):
      pvs_studio fix. misprinted condition
      did make amalgamate

Niels Lohmann (125):
      :sparkles: added a SAX parser #971
      :hammer: fixed test cases to be more robust
      :white_check_mark: added more tests for SAX parsing
      :hammer: removed a logic error and improved coverage
      :ok_hand: fixed some compiler warnings
      :memo: overworked README
      :recycle: refactored SAX parser
      :hammer: added a SAX-DOM-Parser
      :rotating_light: fixed a linter warning
      :green_heart: fixed test case
      :hammer: added error messages to SAX interface
      :hammer: added SAX-DOM-Parser
      :hammer: simplified SAX-DOM parser
      :hammer: using the SAX-DOM parser
      :green_heart: added regression tests for #972 and #977
      :recycle: refined SFINAE to fix some warnings
      :green_heart: added another test case
      :fire: replaced acceptor with SAX parser
      :ok_hand: fixed some more warnings
      :hammer: trying to fix the leak
      :fire: removing failing test (work on this in branch "leak")
      :ambulance: hopefully fixed the memory leak
      :memo: cleanup after #1001
      :ok_hand: made changes proposed in #1001
      :green_heart: improved test coverage
      :recycle: refactored binary readers to use a SAX parser
      :hammer: cleaner exception interface
      :memo: thanks for #1006
      :recycle: adjusting lexer/parser in symmetry to #1006
      :hammer: fixed compilation error
      :checkered_flag: fixed an MSVC warning
      :checkered_flag: experimenting with /Wall
      :checkered_flag: moved /Wall to CMake
      :rewind: oops
      :bookmark: set version to 3.1.2
      :bookmark: set version to 3.1.2
      :recycle: implemented a non-recursive parser
      :white_check_mark: improved test coverage
      :hammer: cleanup
      :construction: started a SAX/DOM/callback parser
      :hammer: some refactoring
      :recycle: proper use of SAX parser for binary formats
      :sparkles: implemented non-throwing binary reader
      :white_check_mark: improved test coverage
      :memo: updated documentation
      :white_check_mark: more tests
      :white_check_mark: improved coverage
      :white_check_mark: improved test coverage
      :hammer: changed SAX interface
      :ambulance: fix for #1021
      :hammer: improved code #1021
      :hammer: realized callback parser wirh SAX interface #971
      :memo: fixed example for operator> #1029
      :green_heart: fixed Valgrind options #1030
      :hammer: using a vector<bool> for the parser hierarchy
      :hammer: cleanup
      :construction: added input adapter for wide strings #1031
      :hammer: trying to make tests run with MSVC #1031
      :hammer: trying to make tests run with MSVC #1031
      :ok_hand: fixed compiler warnings #1031
      :white_check_mark: improved test coverage #1031
      :hammer: removing unget_character() function from input adapters #834
      :hammer: cleanup
      :ambulance: fixed commit 1e08654
      :hankey: first try on #1045
      :construction_worker: added Xcode 9.3 builder
      :memo: updated THANKS list
      :fire: removed commented-out test cases #1060
      :page_facing_up: added SPDX-License-Identifier
      :memo: added public key used for commits and releases
      :wrench: update issue templates
      :fire: removed old issue template
      Update issue templates
      :hammer: removed unget function for wstring parsers
      :ambulance: fixed error in callback logic
      :white_check_mark: added more tests from recent nst's JSONTestSuite
      :white_check_mark: adjusted test cases
      :zap: keys are now returned as const reference #1098
      :ok_hand: mitigating cppcheck bug #1101
      :hammer: only calculate array index string when needed #1098
      :memo: added documentation
      :ambulance: adjusted Fuzzer to new parser
      :memo: documentation to avoid future issues like #1108
      :lipstick: cleanup
      :memo: documentation fix
      :memo: fix for #1052 #1139
      :rotating_light: removed compiler warnings
      :rotating_light: fixed more compiler warnings
      :rotating_light: fixed more compiler warnings
      :construction_worker: tryping different platforms for AppVeyor
      :hammer: small refactoring to improve branch coverage
      :lipstick: fixed indentation
      :construction_worker: experimenting with AppVeyor and MinGW
      :construction_worker: forgot quotes
      :construction_worker: set build type
      :construction_worker: using help from https://stackoverflow.com/a/48509334/266378
      :construction_worker: forgot old PATH
      :construction_worker: trying a more recent compiler
      :hammer: fixed escaping for MinGW
      :construction_worker: using Ninja to speed up build
      :construction_worker: choosing correct image
      :memo: mentioned MinGW in README
      :hammer: added macro to disable compiler check #1128
      :hammer: cleanup after #1134
      :memo: added note about CocoaPods #1148
      :checkered_flag: fix for #1168
      :ambulance: fix for #1169
      :checkered_flag: trying to fix C2440 error
      :checkered_flag: implicit conversion is not allowed with MSVC
      :construction_worker: added more CI workers
      :construction_worker: added more CI workers
      :memo: updated documentation of used compilers
      :art: reindented code
      :rotating_light: fixing a MinGW warning #1192
      :hammer: fixed a MinGW error #1193
      :rotating_light: fixed some compiler warnings
      :memo: overworked documentation
      :bug: fixed callback-related issue (https://github.com/nlohmann/json/issues/971#issuecomment-413678360)
      :rotating_light: fixed a compiler warning
      :memo: release preparation
      :arrow_up: Catch 1.12.0
      :memo: added example for sax_parse
      :bookmark: preparing 3.2.0 release
      :hammer: fixed amalgamation
      :bookmark: set version to 3.2.0

Sonu Lohani (1):
      Fixed compiler error in VS 2015 for debug mode https://github.com/nlohmann/json/issues/1114

Théo DELRIEU (11):
      missing CHECK_NOTHROW in unit-udt
      support construction from other basic_json types
      Provide a from_json overload for std::map
      from_json: add missing template arguments for std::map
      from_json: add overload for std::unordered_map
      run make amalgamate
      split meta.hpp, add detected_t (used to define concepts)
      use templates in the sax interface instead of virtuals
      remove no_limit constant and default values
      use abstract sax class in parser tests
      add static_asserts on SAX interface

Tsz-Ho Yu (1):
      Fix -Wno-sometimes-uninitialized by initializing "result" in parse_sax

Vitaliy (4):
      test (non)equality for alt_string implementation
      define global operator< for const char* and alt_string
      forward declarations to make new compilers happy
      simplify templates for operators, add more checks

Vitaliy Manushkin (5):
      dump to alternate implementation of string, as defined in basic_json template
      dump to alternate implementation of string, as defined in basic_json template (changes to amalgamated code)
      forward alternative string class from output_adapter to output_string_adapter
      add unit test: checking dump to alternative string type
      test refactoring

Wilson (1):
      Make integration section concise

martin-mfg (1):
      fix typo in readme
```