### PR TITLE
COMP: Fix python-packages external project removing hard-coded site-packages path

### DIFF
--- a/SuperBuild/External_python-packages.cmake
+++ b/SuperBuild/External_python-packages.cmake
@@ -37,7 +37,7 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(python_packages_DIR "${CMAKE_BINARY_DIR}/python-packages-install")
   file(TO_NATIVE_PATH ${python_packages_DIR} python_packages_DIR_NATIVE_DIR)
 
-  set(python_sitepackages_DIR "${CMAKE_BINARY_DIR}/python-packages-install/lib/python3.6/site-packages")
+  set(python_sitepackages_DIR "${CMAKE_BINARY_DIR}/python-packages-install/${PYTHON_SITE_PACKAGES_SUBDIR}")
   file(TO_NATIVE_PATH ${python_sitepackages_DIR} python_sitepackages_DIR_NATIVE_DIR)
 
 


### PR DESCRIPTION
Since the variable `PYTHON_SITE_PACKAGES_SUBDIR` was introduced
in Slicer/Slicer@90c0fbce1 (ENH: Introduce `PYTHON_STDLIB_SUBDIR`
and `PYTHON_SITE_PACKAGES_SUBDIR` CMake vars), build of the extension
against the stable version is expected to work.