### PR TITLE
COMP: Fix python install to prevent main site-packages corruption

### DIFF
--- a/SuperBuild/External_python-packages.cmake
+++ b/SuperBuild/External_python-packages.cmake
@@ -50,8 +50,6 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   set(_no_binary "")
 
   # Install jedi and requirements
-  # note: --force-reinstall ensures the python dependency is installed within
-  #       this library's prefix for packaging.
   set(_install_jedi COMMAND ${CMAKE_COMMAND}
       -E env
         PYTHONNOUSERSITE=1
@@ -63,7 +61,6 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
           xeus-python-shell==${${CMAKE_PROJECT_NAME}_xeus_python_shell_VERSION}
           ${_no_binary}
           --prefix ${python_packages_DIR_NATIVE_DIR}
-          --force-reinstall
           --no-warn-script-location
     )
 


### PR DESCRIPTION
This commit reverts use of `--force-reinstall` originally introduced in c59b08fa9 (Fix python package installation).

The use of `--force-reinstall` led to removal of package like `setuptools` from the `site-packages` directory associated with the application and was causing the build of following extension (e.g SlicerRadiomics) to fail.

See https://discourse.slicer.org/t/factory-build-of-python-extensions-conflicting-with-each-other/21935